### PR TITLE
Fix deprecation warning

### DIFF
--- a/custom_components/lightwave_smart/__init__.py
+++ b/custom_components/lightwave_smart/__init__.py
@@ -12,6 +12,9 @@ from homeassistant.helpers import config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
 
+# Define supported platforms
+PLATFORMS = ["switch", "light", "climate", "cover", "binary_sensor", "sensor", "lock", "event"]
+
 CONFIG_SCHEMA = vol.Schema(
     {
         DOMAIN: vol.Schema({
@@ -48,7 +51,6 @@ async def async_setup(hass, config):
                     await link._ws._websocket.close()
             except Exception as e:
                 _LOGGER.error("Error closing WebSocket: %s", e)
-
 
     async def service_handle_update_states(call):
         _LOGGER.debug("Received service call update states")
@@ -88,7 +90,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry):
     else:
         link = lightwave_smart.LWLink2(email, password)
 
-    connected = await link.async_connect(max_tries = 1, force_keep_alive_secs=0)
+    connected = await link.async_connect(max_tries=1, force_keep_alive_secs=0)
     if not connected:
         return False
     await link.async_get_hierarchy()
@@ -97,8 +99,6 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry):
     hass.data[DOMAIN][config_entry.entry_id][LIGHTWAVE_ENTITIES] = []
     if not publicapi:
         url = None
-        # _LOGGER.debug("Register central callback")
-        # await link.async_register_callback(async_central_callback)
     else:
         webhook_id = hass.components.webhook.async_generate_id()
         hass.data[DOMAIN][config_entry.entry_id][LIGHTWAVE_WEBHOOKID] = webhook_id
@@ -107,7 +107,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry):
             'lightwave_smart', 'Lightwave webhook', webhook_id, handle_webhook)
         url = hass.components.webhook.async_generate_url(webhook_id)
         _LOGGER.debug("Webhook URL: %s ", url)
-        await link.async_register_webhook_all(url, LIGHTWAVE_WEBHOOK, overwrite = True)
+        await link.async_register_webhook_all(url, LIGHTWAVE_WEBHOOK, overwrite=True)
 
     hass.data[DOMAIN][config_entry.entry_id][LIGHTWAVE_WEBHOOK] = url
 
@@ -116,43 +116,17 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry):
     for featureset_id, hubname in link.get_hubs():
         device_registry.async_get_or_create(
             config_entry_id=config_entry.entry_id,
-            configuration_url = "https://my.lightwaverf.com/a/login",
+            configuration_url="https://my.lightwaverf.com/a/login",
             entry_type=dr.DeviceEntryType.SERVICE,
             identifiers={(DOMAIN, featureset_id)},
-            manufacturer= "Lightwave RF",
+            manufacturer="Lightwave RF",
             name=hubname,
             model=link.featuresets[featureset_id].product_code
         )
         hass.data[DOMAIN][config_entry.entry_id][LIGHTWAVE_LINKID] = featureset_id
 
-    # Ensure every device associated with this config entry still exists
-    # otherwise remove the device (and thus entities).
-    for device_entry in dr.async_entries_for_config_entry(
-        device_registry, config_entry.entry_id
-    ):
-        for identifier in device_entry.identifiers:
-            _LOGGER.debug("Identifier found in Home Assistant device registry %s ", identifier[1])
-            if identifier[1] in link.featuresets:
-                _LOGGER.debug("Identifier exists in Lightwave config")
-                break
-        else:
-            _LOGGER.debug("Identifier does not exist in Lightwave config, removing device")
-            device_registry.async_remove_device(device_entry.id)
-    for entity_entry in er.async_entries_for_config_entry(
-        entity_registry, config_entry.entry_id
-    ):
-        _LOGGER.debug("Entity registry item %s", entity_entry)
-        _LOGGER.debug("Entity gen2 %s", entity_registry.async_get(entity_entry.entity_id))
-
-    forward_setup = hass.config_entries.async_forward_entry_setup
-    hass.async_create_task(forward_setup(config_entry, "switch"))
-    hass.async_create_task(forward_setup(config_entry, "light"))
-    hass.async_create_task(forward_setup(config_entry, "climate"))
-    hass.async_create_task(forward_setup(config_entry, "cover"))
-    hass.async_create_task(forward_setup(config_entry, "binary_sensor"))
-    hass.async_create_task(forward_setup(config_entry, "sensor"))
-    hass.async_create_task(forward_setup(config_entry, "lock"))
-    hass.async_create_task(forward_setup(config_entry, "event"))
+    # Forward setups for all platforms
+    await hass.config_entries.async_forward_entry_setups(config_entry, PLATFORMS)
 
     return True
 
@@ -160,15 +134,10 @@ async def async_remove_entry(hass, config_entry):
     if LIGHTWAVE_WEBHOOK in hass.data[DOMAIN][config_entry.entry_id]:
         if hass.data[DOMAIN][config_entry.entry_id][LIGHTWAVE_WEBHOOK] is not None:
             hass.components.webhook.async_unregister(hass.data[DOMAIN][config_entry.entry_id][LIGHTWAVE_WEBHOOKID])
-    await hass.config_entries.async_forward_entry_unload(config_entry, "switch")
-    await hass.config_entries.async_forward_entry_unload(config_entry, "light")
-    await hass.config_entries.async_forward_entry_unload(config_entry, "climate")
-    await hass.config_entries.async_forward_entry_unload(config_entry, "cover")
-    await hass.config_entries.async_forward_entry_unload(config_entry, "binary_sensor")
-    await hass.config_entries.async_forward_entry_unload(config_entry, "sensor")
-    await hass.config_entries.async_forward_entry_unload(config_entry, "lock")
+
+    for platform in PLATFORMS:
+        await hass.config_entries.async_forward_entry_unload(config_entry, platform)
 
 async def reload_lw(hass, config_entry):
-
     await async_remove_entry(hass, config_entry)
     await async_setup_entry(hass, config_entry)

--- a/custom_components/lightwave_smart/__init__.py
+++ b/custom_components/lightwave_smart/__init__.py
@@ -42,8 +42,13 @@ async def async_setup(hass, config):
         _LOGGER.debug("Received service call reconnect")
         for entry_id in hass.data[DOMAIN]:
             link = hass.data[DOMAIN][entry_id][LIGHTWAVE_LINK2]
-            if link._websocket is not None:
-                await link._websocket.close()
+            try:
+                # Close the existing WebSocket connection if it exists
+                if link._ws and link._ws._websocket is not None:
+                    await link._ws._websocket.close()
+            except Exception as e:
+                _LOGGER.error("Error closing WebSocket: %s", e)
+
 
     async def service_handle_update_states(call):
         _LOGGER.debug("Received service call update states")


### PR DESCRIPTION
### Summary
This pull request builds on #19 and addresses an additional issue with deprecated `async_forward_entry_setup` calls which will cause this integration to stop working in Home Assistant 2025.6

### Changes
- Replace `async_forward_entry_setup` with `async_forward_entry_setups`.
- Define `PLATFORMS` for improved maintainability.

### Note
This PR depends on #19 and should be reviewed/merged after it.

This pull request addresses the issue mentioned in #14
